### PR TITLE
Fix the error while invoking ':Denite gtags_file

### DIFF
--- a/rplugin/python3/denite/source/gtags_file.py
+++ b/rplugin/python3/denite/source/gtags_file.py
@@ -18,5 +18,5 @@ class Source(TagsBase):
     def get_search_flags(self):
         return [['-f', '--result=ctags-mod']]
 
-    def get_search_word(self, context):
+    def _get_search_word(self, context):
         return context['__filename']


### PR DESCRIPTION
While executing :Denite gtags_file, below error is returned.
[denite] [denite-gtags] Error: Invalid arguments

I guess this is a typo in the gtags_file source.